### PR TITLE
Fix indenting within function literal

### DIFF
--- a/cljfmt/src/cljfmt/indent.cljc
+++ b/cljfmt/src/cljfmt/indent.cljc
@@ -125,7 +125,11 @@
   [zloc]
   (if (and (some-> zloc zip/leftmost zip/right zl/skip-whitespace zl/zlinebreak?)
            (-> zloc z/leftmost z/tag (= :token)))
-    (+ (-> zloc zip/up margin) indent-size)
+    (+ (-> zloc zip/up margin)
+       indent-size
+       (if (= :fn (-> zloc z/up z/tag))
+         1
+         0))
     (if (> (index-of zloc) 1)
       (-> zloc zip/leftmost z/right margin)
       (coll-indent zloc))))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -86,8 +86,14 @@
            (reformat-string "#(while true\n(println :foo))")))
     (is (= "#(reify Closeable\n   (close [_]\n     (prn %)))"
            (reformat-string "#(reify Closeable\n(close [_]\n(prn %)))")))
-    (is (= "(mapv\n  #(vector\n    {:foo %\n     :bar 123}\n    %)\n  xs)"
-           (reformat-string "(mapv\n #(vector\n {:foo %\n  :bar 123}\n       %)\nxs)"))))
+    (is (= "(mapv\n  #(vector\n     {:foo %\n      :bar 123}\n     %)\n  xs)"
+           (reformat-string "(mapv\n #(vector\n {:foo %\n  :bar 123}\n       %)\nxs)")))
+    (is (= "#(foo\n   bar\n   baz)"
+           (reformat-string "#(foo\nbar\nbaz)")))
+    (is (= "#(foo bar\n      baz)"
+           (reformat-string "#(foo bar\nbaz)")))
+    (is (= "#(foo bar\n   baz)"
+           (reformat-string "#(foo bar\nbaz)" '{:indents {foo [[:block 1]]}}))))
 
   (testing "comments"
     (is (= ";foo\n(def x 1)"


### PR DESCRIPTION
There appears to be a bug that when `list-indent` is called in a `#(...)` form, the `#` character isn't accounted for, making the inner forms look one space short. Note that this bug only comes into play when the inner form doesn't match any custom indent rules.

```clojure
;; Before
(do
  (a-thing))
#(do
   (a-thing))
(foo
  (bar))
#(foo
  (bar))   ; <-- !!!


;; After (with my fix)
(do
  (a-thing))
#(do
   (a-thing))
(foo
  (bar))
#(foo
   (bar))
```