### PR TITLE
cond does not stair-step pairs with nothing above or below it

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -35,7 +35,30 @@
     (is (= "(cond-> x\n  a?\n    (a 123)\n  b?\n    (b true))"
            (reformat-string "(cond-> x \n  a?\n(a 123)\n  b?\n(b true))")))
     (is (= "(cond->> x\n  a? a\n  b? b)"
-           (reformat-string "(cond->> x\na? a\nb? b)"))))
+           (reformat-string "(cond->> x\na? a\nb? b)")))
+    (is (= "(cond-> x\n  a?\n  (a 123)\n\n  b?\n  (b true))"
+           (reformat-string "(cond-> x\na?\n(a 123)\n\nb?\n(b true))")))
+    (is (= "
+(cond
+  b
+  c
+  ;; some comment
+  d
+    e
+  f
+    g
+
+  h ; comment
+  i ; another comment
+
+  j k
+  l
+    m
+
+  n
+    o
+  p)"
+           (reformat-string "\n(cond\nb\nc\n  ;; some comment\nd\ne\nf\ng\n\nh ; comment\ni ; another comment\n\nj k\nl\nm\n\nn\no\np)"))))
 
   (testing "constant indentation"
     (is (= "(def foo\n  \"Hello World\")"


### PR DESCRIPTION
The `cond` "stair-step" behavior was originally added to add clarity to the predicates and the results, but if a cond is written with blank lines in between pairs, that added clarity is unnecessary. My proposed change to the `cond` rule would suppress that behavior for a pair if there is nothing interesting directly above or below it.

With the new rule, the following bodies are now _both_ considered valid:
```clojure
(cond
  (or (even? x) (> x 5))
    (call-foo x)
  (odd? x)
    (call-bar x)
  :else
    (call-baz x))
```
```clojure
(cond
  (or (even? x) (> x 5))
  (call-foo x)

  (odd? x)
  (call-bar x)

  :else
  (call-baz x))
```