### PR TITLE
Fix formatting for namespaced maps

### DIFF
--- a/core/src/cljfmt/format/core.clj
+++ b/core/src/cljfmt/format/core.clj
@@ -237,6 +237,7 @@
   (and (zl/element? zloc)
        (not (zl/reader-macro? (zip/up zloc)))
        (zl/element? (zip/right zloc))
+       ;; allow abutting namespaced maps
        (not= :namespaced-map (-> zloc
                                  (zip/up)
                                  (z/node)

--- a/core/src/cljfmt/format/core.clj
+++ b/core/src/cljfmt/format/core.clj
@@ -236,7 +236,11 @@
   [zloc]
   (and (zl/element? zloc)
        (not (zl/reader-macro? (zip/up zloc)))
-       (zl/element? (zip/right zloc))))
+       (zl/element? (zip/right zloc))
+       (not= :namespaced-map (-> zloc
+                                 (zip/up)
+                                 (z/node)
+                                 (n/tag)))))
 
 
 (defn insert-missing-whitespace

--- a/core/src/cljfmt/format/indent.clj
+++ b/core/src/cljfmt/format/indent.clj
@@ -14,7 +14,8 @@
   {:meta "^", :meta* "#^", :vector "[",       :map "{"
    :list "(", :eval "#=",  :uneval "#_",      :fn "#("
    :set "#{", :deref "@",  :reader-macro "#", :unquote "~"
-   :var "#'", :quote "'",  :syntax-quote "`", :unquote-splicing "~@"})
+   :var "#'", :quote "'",  :syntax-quote "`", :unquote-splicing "~@",
+   :namespaced-map "#"})
 
 
 
@@ -75,7 +76,10 @@
           (apply str new-worklist)))
       (if-let [p (zip/up zloc)]
         ;; newline cannot be introduced by start-element
-        (recur p (cons (start-element (n/tag (z/node p))) worklist))
+        (if (and (= :namespaced-map (n/tag (z/node p)))
+                 (line-break-next? (z/next p)))
+          (recur p worklist)
+          (recur p (cons (start-element (n/tag (z/node p))) worklist)))
         (apply str worklist)))))
 
 

--- a/core/src/cljfmt/format/indent.clj
+++ b/core/src/cljfmt/format/indent.clj
@@ -75,10 +75,12 @@
           (recur p new-worklist)
           (apply str new-worklist)))
       (if-let [p (zip/up zloc)]
-        ;; newline cannot be introduced by start-element
+        ;; if a namespaced map's body is on a newline, don't add the
+        ;; start-element to the list of indentation
         (if (and (= :namespaced-map (n/tag (z/node p)))
                  (line-break-next? (z/next p)))
           (recur p worklist)
+          ;; newline cannot be introduced by start-element
           (recur p (cons (start-element (n/tag (z/node p))) worklist)))
         (apply str worklist)))))
 

--- a/core/test/cljfmt/format/core_test.clj
+++ b/core/test/cljfmt/format/core_test.clj
@@ -23,6 +23,23 @@
          (reformat-string "(t/defrecord Foo\n [x]\nCloseable\n(close [_]\n(prn x)))"))))
 
 
+(deftest namespaced-maps
+  (is (= "#:a{:one 1\n    :two 2}"
+         (reformat-string "#:a{:one 1\n    :two 2}")))
+  (is (= "#:a{:one 1\n    :two 2}"
+         (reformat-string "#:a{:one 1\n    :two 2}" {:insert-missing-whitespace? false})))
+  (is (= "#:a {:one 1\n     :two 2}"
+         (reformat-string "#:a {:one 1\n     :two 2}")))
+  (is (= "#:a {:one 1\n     :two 2}"
+         (reformat-string "#:a {:one 1\n     :two 2}" {:insert-missing-whitespace? false})))
+  (is (= "(let [foo #:abc\n          {:d 1}] (:d foo))"
+         (reformat-string "(let [foo #:abc\n{:d 1}] (:d foo))")))
+  (is (= "#:abc\n{:d 1}"
+         (reformat-string "#:abc\n {:d 1}")))
+  (is (= "#:abc\n{:d 1}"
+         (reformat-string "#:abc\n{:d 1}"))))
+
+
 (deftest comment-handling
   (testing "inline comments"
     (is (= "(let [;foo\n      x (foo bar\n             baz)]\n  x)"
@@ -84,7 +101,4 @@
            (reformat-string "#?@(:clj foo\n:cljs bar)"))))
   (testing "reader macros"
     (is (= "#inst\n\"2018-01-01T00:00:00.000-00:00\""
-           (reformat-string "#inst\n\"2018-01-01T00:00:00.000-00:00\""))))
-  (testing "map prefixes"
-    (is (= "#:abc\n{:d 1}"
-           (reformat-string "#:abc\n{:d 1}")))))
+           (reformat-string "#inst\n\"2018-01-01T00:00:00.000-00:00\"")))))

--- a/core/test/cljfmt/format/core_test.clj
+++ b/core/test/cljfmt/format/core_test.clj
@@ -32,6 +32,10 @@
          (reformat-string "#:a {:one 1\n     :two 2}")))
   (is (= "#:a {:one 1\n     :two 2}"
          (reformat-string "#:a {:one 1\n     :two 2}" {:insert-missing-whitespace? false})))
+  (is (= "(let [foo #:a{:one 1}] (:a/one foo))"
+         (reformat-string "(let [foo #:a{:one 1}] (:a/one foo))")))
+  (is (= "(let [foo #:a {:one 1}] (:a/one foo))"
+         (reformat-string "(let [foo #:a {:one 1}] (:a/one foo))")))
   (is (= "(let [foo #:abc\n          {:d 1}] (:d foo))"
          (reformat-string "(let [foo #:abc\n{:d 1}] (:d foo))")))
   (is (= "#:abc\n{:d 1}"

--- a/core/test/cljfmt/format/indent_test.clj
+++ b/core/test/cljfmt/format/indent_test.clj
@@ -93,5 +93,7 @@
 (deftest embedded-structures
   (is (= "(let [foo {:x 1\n           :y 2}]\n  (:x foo))"
          (reindent-string "(let [foo {:x 1\n:y 2}]\n(:x foo))")))
+  (is (= "(let [foo\n      {:x 1\n       :y 2}]  (:x foo))"
+         (reindent-string "(let [foo\n{:x 1\n:y 2}]  (:x foo))")))
   (is (= "(if foo\n  (do bar\n      baz)\n  quz)"
          (reindent-string "(if foo\n(do bar\nbaz)\nquz)"))))


### PR DESCRIPTION
Fixes #6.

We weren't writing anything for the `start-element` for the `:namespaced-map` node, which means that we weren't accounting for it in the indentation for any subsequent lines.

See also: https://github.com/xsc/rewrite-clj/pull/66