### PR TITLE
Do not skip defn- tokens

### DIFF
--- a/core/src/cljfmt/format/core.clj
+++ b/core/src/cljfmt/format/core.clj
@@ -97,6 +97,7 @@
   (transform
     form edit-all p?
     (fn [zloc]
+      ; (println zloc (break? zloc))
       (if (break? zloc)
         ; break space
         (if (zl/zlinebreak? zloc)

--- a/core/src/cljfmt/format/core.clj
+++ b/core/src/cljfmt/format/core.clj
@@ -97,7 +97,6 @@
   (transform
     form edit-all p?
     (fn [zloc]
-      ; (println zloc (break? zloc))
       (if (break? zloc)
         ; break space
         (if (zl/zlinebreak? zloc)

--- a/core/src/cljfmt/format/fn.clj
+++ b/core/src/cljfmt/format/fn.clj
@@ -26,13 +26,28 @@
   (nil? (z/find-next zloc zip/left p?)))
 
 
+(defn- fn-sym?
+  "True if the symbol is a function"
+  [symbol & {:keys [exclude-anonymous?]
+             :or {exclude-anonymous? false}}]
+
+  (let [name (name symbol)]
+    (cond
+
+      exclude-anonymous?
+      (contains? #{"defn" "defn-"} name)
+
+      :else
+      (contains? #{"fn" "defn" "defn-"} name))))
+
+
 (defn- fn-form?
   "True if the node at this location is a function form."
   [zloc]
   (and (= :list (z/tag zloc))
        (let [form-sym (zl/form-symbol (z/down zloc))]
          (and (symbol? form-sym)
-              (or (contains? #{"fn" "defn" "defn-"} (name form-sym))
+              (or (fn-sym? form-sym)
                   (and (vector-node? (z/up zloc))
                        (no-prev? zloc vector-node?)
                        (= 'letfn (zl/form-symbol (z/up zloc)))))))))
@@ -67,8 +82,11 @@
          (zl/token? unwrapped)
          (no-prev? zloc arg-vector?)
          (symbol? (z/sexpr unwrapped))
-         (not (contains? #{"fn" "defn" "defn-"} (name (z/sexpr unwrapped))))
-         (contains? #{[] ["fn"] ["defn"] ["defn-"]} (map name (preceeding-symbols zloc))))))
+         (not (fn-sym? (z/sexpr unwrapped)))
+         (let [preceeding (preceeding-symbols zloc)]
+           (or (empty? preceeding)
+               (and (= 1 (count preceeding))
+                    (fn-sym? (first preceeding))))))))
 
 
 (defn fn-to-name-or-args-space?
@@ -109,5 +127,5 @@
   "True if this location is inside a `defn` or a multi-line form."
   [zloc]
   (or (when-let [fsym (zl/form-symbol zloc)]
-        (and (symbol? fsym) (contains? #{"defn" "defn-"} (name fsym))))
+        (and (symbol? fsym) (fn-sym? fsym :exclude-anonymous? true)))
       (zl/multiline? (z/up zloc))))

--- a/core/src/cljfmt/format/fn.clj
+++ b/core/src/cljfmt/format/fn.clj
@@ -32,8 +32,7 @@
   (and (= :list (z/tag zloc))
        (let [form-sym (zl/form-symbol (z/down zloc))]
          (and (symbol? form-sym)
-              (or (= "fn" (name form-sym))
-                  (= "defn" (name form-sym))
+              (or (contains? #{"fn" "defn" "defn-"} (name form-sym))
                   (and (vector-node? (z/up zloc))
                        (no-prev? zloc vector-node?)
                        (= 'letfn (zl/form-symbol (z/up zloc)))))))))
@@ -68,8 +67,8 @@
          (zl/token? unwrapped)
          (no-prev? zloc arg-vector?)
          (symbol? (z/sexpr unwrapped))
-         (not (contains? #{"fn" "defn"} (name (z/sexpr unwrapped))))
-         (contains? #{[] ["fn"] ["defn"]} (map name (preceeding-symbols zloc))))))
+         (not (contains? #{"fn" "defn" "defn-"} (name (z/sexpr unwrapped))))
+         (contains? #{[] ["fn"] ["defn"] ["defn-"]} (map name (preceeding-symbols zloc))))))
 
 
 (defn fn-to-name-or-args-space?
@@ -110,5 +109,5 @@
   "True if this location is inside a `defn` or a multi-line form."
   [zloc]
   (or (when-let [fsym (zl/form-symbol zloc)]
-        (and (symbol? fsym) (= "defn" (name fsym))))
+        (and (symbol? fsym) (= "defn-" (name fsym))))
       (zl/multiline? (z/up zloc))))

--- a/core/src/cljfmt/format/fn.clj
+++ b/core/src/cljfmt/format/fn.clj
@@ -109,5 +109,5 @@
   "True if this location is inside a `defn` or a multi-line form."
   [zloc]
   (or (when-let [fsym (zl/form-symbol zloc)]
-        (and (symbol? fsym) (= "defn-" (name fsym))))
+        (and (symbol? fsym) (contains? #{"defn" "defn-"} (name fsym))))
       (zl/multiline? (z/up zloc))))

--- a/core/test/cljfmt/format/fn_test.clj
+++ b/core/test/cljfmt/format/fn_test.clj
@@ -26,29 +26,31 @@
 
 
 (deftest function-forms
-  (is (= "(fn [x y] x)"
-         (reformat-string "(fn [x y] x)")))
-  (is (= "(fn [x y]\n  x)"
-         (reformat-string "(fn\n  [x y]\n  x)")))
-  (is (= "(fn foo [x y] x)"
-         (reformat-string "(fn foo [x y] x)")))
-  (is (= "(fn foo\n  [x y]\n  x)"
-         (reformat-string "(fn foo [x y]\nx)")))
-  (is (= "(fn ([x]\n     (foo)\n     (bar)))"
-         (reformat-string "(fn\n([x]\n(foo)\n(bar)))")))
-  (is (= "(defn foo\n  [x y]\n  x)"
+  ; (is (= "(fn [x y] x)"
+  ;        (reformat-string "(fn [x y] x)")))
+  ; (is (= "(fn [x y]\n  x)"
+  ;        (reformat-string "(fn\n  [x y]\n  x)")))
+  ; (is (= "(fn foo [x y] x)"
+  ;        (reformat-string "(fn foo [x y] x)")))
+  ; (is (= "(fn foo\n  [x y]\n  x)"
+  ;        (reformat-string "(fn foo [x y]\nx)")))
+  ; (is (= "(fn ([x]\n     (foo)\n     (bar)))"
+  ;        (reformat-string "(fn\n([x]\n(foo)\n(bar)))")))
+  (is (= "(defn foo\n  [x y]\n   x)"
          (reformat-string "(defn foo [x y] x)")))
-  (is (= "(defn foo\n  [x y]\n  x)"
-         (reformat-string "(defn foo [x y]\n  x)")))
-  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-         (reformat-string "(defn foo \"docs\" [x y] x)")))
-  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-         (reformat-string "(defn foo \"docs\" [x y]\n  x)")))
-  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-         (reformat-string "(defn foo \"docs\"\n[x y]x)")))
-  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-         (reformat-string "(defn foo\n\"docs\"\n[x y] \nx)")))
-  (is (= "(defn foo\n  ([x]\n   (foo)\n   (bar)))"
-         (reformat-string "(defn foo\n([x]\n(foo)\n(bar)))")))
-  (is (= "(defn ^:deprecated foo\n  \"Deprecated method.\"\n  [x]\n  123)"
+  (is (= "(defn- foo\n  [x y]\n  x)"
+         (reformat-string "(defn- foo [x y] x)")))
+  ; (is (= "(defn foo\n  [x y]\n  x)"
+  ;        (reformat-string "(defn foo [x y]\n  x)")))
+  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+  ;        (reformat-string "(defn foo \"docs\" [x y] x)")))
+  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+  ;        (reformat-string "(defn foo \"docs\" [x y]\n  x)")))
+  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+  ;        (reformat-string "(defn foo \"docs\"\n[x y]x)")))
+  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+  ;        (reformat-string "(defn foo\n\"docs\"\n[x y] \nx)")))
+  ; (is (= "(defn foo\n  ([x]\n   (foo)\n   (bar)))"
+  ;        (reformat-string "(defn foo\n([x]\n(foo)\n(bar)))")))
+  #_(is (= "(defn ^:deprecated foo\n  \"Deprecated method.\"\n  [x]\n  123)"
          (reformat-string "(defn ^:deprecated foo \"Deprecated method.\"\n[x]\n123)"))))

--- a/core/test/cljfmt/format/fn_test.clj
+++ b/core/test/cljfmt/format/fn_test.clj
@@ -26,31 +26,47 @@
 
 
 (deftest function-forms
-  ; (is (= "(fn [x y] x)"
-  ;        (reformat-string "(fn [x y] x)")))
-  ; (is (= "(fn [x y]\n  x)"
-  ;        (reformat-string "(fn\n  [x y]\n  x)")))
-  ; (is (= "(fn foo [x y] x)"
-  ;        (reformat-string "(fn foo [x y] x)")))
-  ; (is (= "(fn foo\n  [x y]\n  x)"
-  ;        (reformat-string "(fn foo [x y]\nx)")))
-  ; (is (= "(fn ([x]\n     (foo)\n     (bar)))"
-  ;        (reformat-string "(fn\n([x]\n(foo)\n(bar)))")))
-  (is (= "(defn foo\n  [x y]\n   x)"
+  (is (= "(fn [x y] x)"
+         (reformat-string "(fn [x y] x)")))
+  (is (= "(fn [x y]\n  x)"
+         (reformat-string "(fn\n  [x y]\n  x)")))
+  (is (= "(fn foo [x y] x)"
+         (reformat-string "(fn foo [x y] x)")))
+  (is (= "(fn foo\n  [x y]\n  x)"
+         (reformat-string "(fn foo [x y]\nx)")))
+  (is (= "(fn ([x]\n     (foo)\n     (bar)))"
+         (reformat-string "(fn\n([x]\n(foo)\n(bar)))")))
+  (is (= "(defn foo\n  [x y]\n  x)"
          (reformat-string "(defn foo [x y] x)")))
+  (is (= "(defn foo\n  [x y]\n  x)"
+         (reformat-string "(defn foo [x y]\n  x)")))
+  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn foo \"docs\" [x y] x)")))
+  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn foo \"docs\" [x y]\n  x)")))
+  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn foo \"docs\"\n[x y]x)")))
+  (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn foo\n\"docs\"\n[x y] \nx)")))
+  (is (= "(defn foo\n  ([x]\n   (foo)\n   (bar)))"
+         (reformat-string "(defn foo\n([x]\n(foo)\n(bar)))")))
+  (is (= "(defn ^:deprecated foo\n  \"Deprecated method.\"\n  [x]\n  123)"
+         (reformat-string "(defn ^:deprecated foo \"Deprecated method.\"\n[x]\n123)")))
+
+  ;; private function forms
   (is (= "(defn- foo\n  [x y]\n  x)"
          (reformat-string "(defn- foo [x y] x)")))
-  ; (is (= "(defn foo\n  [x y]\n  x)"
-  ;        (reformat-string "(defn foo [x y]\n  x)")))
-  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-  ;        (reformat-string "(defn foo \"docs\" [x y] x)")))
-  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-  ;        (reformat-string "(defn foo \"docs\" [x y]\n  x)")))
-  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-  ;        (reformat-string "(defn foo \"docs\"\n[x y]x)")))
-  ; (is (= "(defn foo\n  \"docs\"\n  [x y]\n  x)"
-  ;        (reformat-string "(defn foo\n\"docs\"\n[x y] \nx)")))
-  ; (is (= "(defn foo\n  ([x]\n   (foo)\n   (bar)))"
-  ;        (reformat-string "(defn foo\n([x]\n(foo)\n(bar)))")))
-  #_(is (= "(defn ^:deprecated foo\n  \"Deprecated method.\"\n  [x]\n  123)"
-         (reformat-string "(defn ^:deprecated foo \"Deprecated method.\"\n[x]\n123)"))))
+  (is (= "(defn- foo\n  [x y]\n  x)"
+         (reformat-string "(defn- foo [x y]\n  x)")))
+  (is (= "(defn- foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn- foo \"docs\" [x y] x)")))
+  (is (= "(defn- foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn- foo \"docs\" [x y]\n  x)")))
+  (is (= "(defn- foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn- foo \"docs\"\n[x y]x)")))
+  (is (= "(defn- foo\n  \"docs\"\n  [x y]\n  x)"
+         (reformat-string "(defn- foo\n\"docs\"\n[x y] \nx)")))
+  (is (= "(defn- foo\n  ([x]\n   (foo)\n   (bar)))"
+         (reformat-string "(defn- foo\n([x]\n(foo)\n(bar)))")))
+  (is (= "(defn- ^:deprecated foo\n  \"Deprecated method.\"\n  [x]\n  123)"
+         (reformat-string "(defn- ^:deprecated foo \"Deprecated method.\"\n[x]\n123)"))))


### PR DESCRIPTION
The PR fixes issue: https://github.com/greglook/cljfmt/issues/17

Looks like `cljfmt/format/fn.clj` wasn't considering `defn-` tokens in totality which resulted in it skipping `defn-`.